### PR TITLE
Close #113, Upgrade minSDK to Oreo 26

### DIFF
--- a/buildSrc/src/main/java/AppSettings.kt
+++ b/buildSrc/src/main/java/AppSettings.kt
@@ -2,7 +2,7 @@ object AppSettings {
     const val VERSION_CODE = 1922210109
     const val VERSION_NAME = "2.2.0"
     const val COMPILE_SDK_VERSION = 35
-    const val MIN_SDK_VERSION = 24
+    const val MIN_SDK_VERSION = 26
     const val TARGET_SDK_VERSION = 35
     const val APPLICATION_ID = "liou.rayyuan.ebooksearchtaiwan"
 }


### PR DESCRIPTION
### Changes:
  - Add LikerLand to the default settings
  - Upgrade minSDK to Oreo 26. As title.