### PR TITLE
Enhancement/migrate compose

### DIFF
--- a/app/src/main/java/liou/rayyuan/ebooksearchtaiwan/ui/theme/EBookTheme.kt
+++ b/app/src/main/java/liou/rayyuan/ebooksearchtaiwan/ui/theme/EBookTheme.kt
@@ -3,6 +3,7 @@ package liou.rayyuan.ebooksearchtaiwan.ui.theme
 import android.content.res.Configuration
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,8 +34,9 @@ fun EBookTheme(
         LocalColorScheme provides colorScheme,
         LocalDrawableResources provides drawableResources,
         LocalIndication provides ripple(),
-        content = content
-    )
+    ) {
+        MaterialTheme(content = content)
+    }
 }
 
 object EBookTheme {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Library versions
 coil = "3.3.0"
 desugarLibVersion = "2.1.5"
-koin = "4.1.0"
+koin = "4.1.1"
 fuzzywuzzy = "1.4.0"
 guavaVersion = "31.1-android" # To prevent Guava conflict, use this old version
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,10 +42,10 @@ admob = "24.3.0"
 inAppReview = "2.0.2"
 
 #  Test related
-androidxTestExt = "1.2.1"
-androidxTestRunner = "1.6.2"
-androidxTestCore = "1.6.1"
-androidxEspresso = "3.6.1"
+androidxTestExt = "1.3.0"
+androidxTestRunner = "1.7.0"
+androidxTestCore = "1.7.0"
+androidxEspresso = "3.7.0"
 
 # plugins versions
 androidGradlePlugin = "8.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Library versions
-coil = "3.2.0"
+coil = "3.3.0"
 desugarLibVersion = "2.1.5"
 koin = "4.1.0"
 fuzzywuzzy = "1.4.0"
@@ -18,16 +18,16 @@ paging = "3.3.6"
 barcodeScanner = "17.3.0"
 
 # Jetpack Compose
-composeBom = "2025.05.01"
-lifecycleCompose = "2.9.1"
-navigationCompose = "2.9.0"
+composeBom = "2025.10.00" # TODO: check the TextInput focus issue in newer version
+lifecycleCompose = "2.9.4"
+navigationCompose = "2.9.5"
 constraintlayoutCompose = "1.1.1"
 requestPermissionCompose = "1.3.2"
 webviewCompose = "0.33.6"
 
 # CameraX
-viewFinderCompose = "1.5.0-beta02"
-cameraXVersion = "1.4.2"
+viewFinderCompose = "1.5.1"
+cameraXVersion = "1.5.1"
 
 #  Kotlin Libraries
 kotlinxCoroutines = "1.10.2"


### PR DESCRIPTION
### Changes
  - Migrate Jetpack Compose 
    - We use 2025.10.10 instead 2025.10.11, because 10.11 will make TextInput focus automatically. Just skip for now. 