### PR TITLE
chore(release): bump app version to 2.3.0

### DIFF
--- a/buildSrc/src/main/java/AppSettings.kt
+++ b/buildSrc/src/main/java/AppSettings.kt
@@ -1,6 +1,6 @@
 object AppSettings {
-    const val VERSION_CODE = 1922210111
-    const val VERSION_NAME = "2.2.1"
+    const val VERSION_CODE = 1922300111
+    const val VERSION_NAME = "2.3.0"
     const val COMPILE_SDK_VERSION = 37
     const val MIN_SDK_VERSION = 26
     const val TARGET_SDK_VERSION = 36


### PR DESCRIPTION
## Changes

  * Raise versionName to 2.3.0 and versionCode to 1922300111 for the next Play Store build.