### PR TITLE
Fix window compatibility crashes and focus regression

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -217,6 +217,7 @@ dependencies {
     implementation(libs.androidx.activity.ktx)
     implementation(libs.material)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.window)
 
     implementation(libs.androidx.browser)
     implementation(libs.androidx.appfunctions)

--- a/app/src/androidTest/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/WindowInsetsCompatibilityInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/WindowInsetsCompatibilityInstrumentedTest.kt
@@ -1,0 +1,49 @@
+package liou.rayyuan.ebooksearchtaiwan.ui.theme
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class WindowInsetsCompatibilityInstrumentedTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun unsupportedSystemOverlays_usesZeroInsets() {
+        var insetValues = emptyList<Int>()
+
+        composeRule.setContent {
+            EBookTheme(hasCompatibleWindowInsetsRuntime = false) {
+                val density = Density(1f)
+                val insets =
+                    listOf(
+                        compatibleSafeDrawingWindowInsets(),
+                        compatibleScaffoldWindowInsets(),
+                        compatibleTopAppBarWindowInsets(),
+                    )
+                SideEffect {
+                    insetValues =
+                        insets.flatMap {
+                            listOf(
+                                it.getLeft(density, LayoutDirection.Ltr),
+                                it.getTop(density),
+                                it.getRight(density, LayoutDirection.Ltr),
+                                it.getBottom(density),
+                            )
+                        }
+                }
+            }
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(List(12) { 0 }, insetValues)
+        }
+    }
+}

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/BaseActivity.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/BaseActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.rayliu.commonmain.domain.service.UserPreferenceManager
 import liou.rayyuan.ebooksearchtaiwan.misc.EventTracker
+import liou.rayyuan.ebooksearchtaiwan.utils.WindowApiCompatibility
 import org.koin.android.ext.android.inject
 
 abstract class BaseActivity(
@@ -70,6 +71,10 @@ abstract class BaseActivity(
     }
 
     private fun setupEdgeToEdge() {
+        if (!WindowApiCompatibility.hasCompatibleWindowInsetsRuntime) {
+            return
+        }
+
         val navigationDarkScrimColor = Color.TRANSPARENT
         enableEdgeToEdge(
             statusBarStyle =

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookResultListScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookResultListScreen.kt
@@ -9,12 +9,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
@@ -60,6 +58,8 @@ import liou.rayyuan.ebooksearchtaiwan.booksearch.viewstate.BookResultViewState
 import liou.rayyuan.ebooksearchtaiwan.composable.EBookDropdownMenu
 import liou.rayyuan.ebooksearchtaiwan.composable.OptionMenuItem
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.EBookTheme
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleSafeDrawingWindowInsets
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleTopAppBarWindowInsets
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -198,11 +198,12 @@ fun BookResultListScreen(
                         )
                     }
                 },
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                windowInsets = compatibleTopAppBarWindowInsets()
             )
         },
         containerColor = EBookTheme.colors.colorBackground,
-        contentWindowInsets = WindowInsets.safeDrawing,
+        contentWindowInsets = compatibleSafeDrawingWindowInsets(),
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     ) { paddings ->
         Box(

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchActivity.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchActivity.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import android.util.TypedValue
 import android.widget.Toast
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.ColorInt
@@ -73,7 +72,6 @@ class BookSearchActivity : BaseActivity() {
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setupLauncherCallbacks()

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
 import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
@@ -63,13 +63,14 @@ fun BookSearchScreen(
     var showShareSnapshotOption by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
+    val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
     val paneNavigator: ThreePaneScaffoldNavigator<Book> =
         rememberListDetailPaneScaffoldNavigator<Book>(
             scaffoldDirective =
-                calculateBookSearchPaneScaffoldDirective(currentWindowAdaptiveInfo())
+                calculateBookSearchPaneScaffoldDirective(windowAdaptiveInfo)
         )
     val isDetailPaneVisible = paneNavigator.scaffoldValue.secondary == PaneAdaptedValue.Expanded
-    val isWidthCompact = isWindowWidthCompact()
+    val isWidthCompact = isWindowWidthCompact(windowAdaptiveInfo)
 
     NavigableListDetailPaneScaffold(
         navigator = paneNavigator,

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchScreen.kt
@@ -208,5 +208,16 @@ fun BookSearchScreen(
 }
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
-internal fun calculateBookSearchPaneScaffoldDirective(windowAdaptiveInfo: WindowAdaptiveInfo): PaneScaffoldDirective =
-    calculatePaneScaffoldDirectiveWithTwoPanesOnMediumWidth(windowAdaptiveInfo)
+internal fun calculateBookSearchPaneScaffoldDirective(windowAdaptiveInfo: WindowAdaptiveInfo): PaneScaffoldDirective {
+    val directive = calculatePaneScaffoldDirectiveWithTwoPanesOnMediumWidth(windowAdaptiveInfo)
+    return PaneScaffoldDirective(
+        maxHorizontalPartitions = directive.maxHorizontalPartitions,
+        horizontalPartitionSpacerSize = directive.horizontalPartitionSpacerSize,
+        maxVerticalPartitions = directive.maxVerticalPartitions,
+        verticalPartitionSpacerSize = directive.verticalPartitionSpacerSize,
+        defaultPanePreferredWidth = directive.defaultPanePreferredWidth,
+        defaultPanePreferredHeight = directive.defaultPanePreferredHeight,
+        excludedBounds = directive.excludedBounds,
+        shouldAutoFocusCurrentDestination = false
+    )
+}

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/composable/DetailPaneEmptyState.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/composable/DetailPaneEmptyState.kt
@@ -3,10 +3,8 @@ package liou.rayyuan.ebooksearchtaiwan.booksearch.composable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
@@ -19,12 +17,13 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import liou.rayyuan.ebooksearchtaiwan.R
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleSafeDrawingWindowInsets
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.pale_slate
 
 @Composable
 fun DetailPaneEmptyState(modifier: Modifier = Modifier,) {
     Scaffold(
-        contentWindowInsets = WindowInsets.safeDrawing,
+        contentWindowInsets = compatibleSafeDrawingWindowInsets(),
         modifier = modifier,
     ) { paddings ->
         Box(

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/util/WindowWidthAdaptive.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/util/WindowWidthAdaptive.kt
@@ -1,11 +1,7 @@
 package liou.rayyuan.ebooksearchtaiwan.booksearch.util
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
-import androidx.compose.runtime.Composable
-import androidx.window.core.layout.WindowWidthSizeClass
+import androidx.compose.material3.adaptive.WindowAdaptiveInfo
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 
-@Composable
-fun isWindowWidthCompact(): Boolean {
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-    return windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT
-}
+fun isWindowWidthCompact(windowAdaptiveInfo: WindowAdaptiveInfo): Boolean =
+    !windowAdaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/bookstorereorder/BookStoreReorderScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/bookstorereorder/BookStoreReorderScreen.kt
@@ -40,6 +40,8 @@ import liou.rayyuan.ebooksearchtaiwan.composable.iconpack.EBookIcons
 import liou.rayyuan.ebooksearchtaiwan.composable.rememberDragDropState
 import liou.rayyuan.ebooksearchtaiwan.composable.toMutableStateList
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.EBookTheme
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleScaffoldWindowInsets
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleTopAppBarWindowInsets
 import java.util.Collections
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -90,10 +92,12 @@ fun BookStoreReorderScreen(
                             Icon(EBookIcons.BaselineCheck24Px, contentDescription = "Send Result Button")
                         }
                     }
-                }
+                },
+                windowInsets = compatibleTopAppBarWindowInsets()
             )
         },
         containerColor = EBookTheme.colors.colorBackground,
+        contentWindowInsets = compatibleScaffoldWindowInsets(),
         modifier = modifier,
     ) { innerPaddings ->
         val sortedStores = viewModel.sortedStores.collectAsStateWithLifecycle().value

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/camerapreview/BarcodeScanner.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/camerapreview/BarcodeScanner.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.rememberNavController
 import liou.rayyuan.ebooksearchtaiwan.di.barcodeScannerModules
 import liou.rayyuan.ebooksearchtaiwan.camerapreview.permission.CameraPermissionScreen
 import liou.rayyuan.ebooksearchtaiwan.camerapreview.preview.CameraPreviewScreen
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleScaffoldWindowInsets
 import org.koin.androidx.compose.KoinAndroidContext
 import org.koin.compose.getKoin
 
@@ -32,6 +33,7 @@ fun BarcodeScanner(
         Scaffold(
             containerColor = Color.Black,
             contentColor = Color.Black,
+            contentWindowInsets = compatibleScaffoldWindowInsets(),
             modifier = modifier.fillMaxSize()
         ) { paddings ->
             BarcodeScannerNavHost(

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/preferencesetting/PreferenceSettingsScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/preferencesetting/PreferenceSettingsScreen.kt
@@ -44,6 +44,8 @@ import com.alorma.compose.settings.ui.base.internal.SettingsTileDefaults
 import liou.rayyuan.ebooksearchtaiwan.R
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.EBookTheme
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.blue_green_you
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleScaffoldWindowInsets
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleTopAppBarWindowInsets
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.pure_white
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -84,9 +86,11 @@ fun PreferenceSettingsScreen(
                             contentDescription = stringResource(id = R.string.menu_setting)
                         )
                     }
-                }
+                },
+                windowInsets = compatibleTopAppBarWindowInsets()
             )
         },
+        contentWindowInsets = compatibleScaffoldWindowInsets(),
         modifier = modifier
     ) { scaffoldPadding ->
         PreferenceSettingsScreenContent(

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/simplewebview/SimpleWebViewScreen.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/simplewebview/SimpleWebViewScreen.kt
@@ -45,6 +45,8 @@ import liou.rayyuan.ebooksearchtaiwan.composable.iconpack.BaselineClear24Px
 import liou.rayyuan.ebooksearchtaiwan.composable.iconpack.EBookIcons
 import liou.rayyuan.ebooksearchtaiwan.composable.resolveColorAttribute
 import liou.rayyuan.ebooksearchtaiwan.ui.theme.EBookTheme
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleScaffoldWindowInsets
+import liou.rayyuan.ebooksearchtaiwan.ui.theme.compatibleTopAppBarWindowInsets
 
 @SuppressLint("SetJavaScriptEnabled")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -159,10 +161,12 @@ fun SimpleWebViewScreen(
                             }
                         )
                     }
-                }
+                },
+                windowInsets = compatibleTopAppBarWindowInsets()
             )
         },
         containerColor = EBookTheme.colors.colorBackground,
+        contentWindowInsets = compatibleScaffoldWindowInsets(),
         modifier = modifier
     ) { paddings ->
         Box(

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/EBookTheme.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/EBookTheme.kt
@@ -8,10 +8,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
+import liou.rayyuan.ebooksearchtaiwan.utils.WindowApiCompatibility
 
 @Composable
 fun EBookTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    hasCompatibleWindowInsetsRuntime: Boolean = WindowApiCompatibility.hasCompatibleWindowInsetsRuntime,
     content: @Composable () -> Unit
 ) {
     val colorScheme =
@@ -29,6 +31,7 @@ fun EBookTheme(
     CompositionLocalProvider(
         LocalColorScheme provides colorScheme,
         LocalDrawableResources provides drawableResources,
+        LocalHasCompatibleWindowInsetsRuntime provides hasCompatibleWindowInsetsRuntime,
         LocalIndication provides ripple(),
     ) {
         val themeColorScheme =

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/WindowInsetsCompatibility.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/ui/theme/WindowInsetsCompatibility.kt
@@ -1,0 +1,38 @@
+package liou.rayyuan.ebooksearchtaiwan.ui.theme
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import liou.rayyuan.ebooksearchtaiwan.utils.WindowApiCompatibility
+
+internal val LocalHasCompatibleWindowInsetsRuntime =
+    staticCompositionLocalOf { WindowApiCompatibility.hasCompatibleWindowInsetsRuntime }
+
+@Composable
+internal fun compatibleSafeDrawingWindowInsets(): WindowInsets =
+    if (LocalHasCompatibleWindowInsetsRuntime.current) {
+        WindowInsets.safeDrawing
+    } else {
+        WindowInsets(0, 0, 0, 0)
+    }
+
+@Composable
+internal fun compatibleScaffoldWindowInsets(): WindowInsets =
+    if (LocalHasCompatibleWindowInsetsRuntime.current) {
+        ScaffoldDefaults.contentWindowInsets
+    } else {
+        WindowInsets(0, 0, 0, 0)
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun compatibleTopAppBarWindowInsets(): WindowInsets =
+    if (LocalHasCompatibleWindowInsetsRuntime.current) {
+        TopAppBarDefaults.windowInsets
+    } else {
+        WindowInsets(0, 0, 0, 0)
+    }

--- a/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/utils/WindowApiCompatibility.kt
+++ b/app/src/main/kotlin/liou/rayyuan/ebooksearchtaiwan/utils/WindowApiCompatibility.kt
@@ -1,0 +1,31 @@
+package liou.rayyuan.ebooksearchtaiwan.utils
+
+import android.os.Build
+
+internal fun isWindowInsetsRuntimeCompatible(
+    sdkInt: Int,
+    methodExists: () -> Boolean,
+): Boolean {
+    if (sdkInt < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return true
+    }
+
+    return try {
+        methodExists()
+    } catch (_: LinkageError) {
+        false
+    }
+}
+
+internal object WindowApiCompatibility {
+    val hasCompatibleWindowInsetsRuntime: Boolean by lazy {
+        isWindowInsetsRuntimeCompatible(Build.VERSION.SDK_INT) {
+            try {
+                Class.forName("android.view.WindowInsets\$Type").getMethod("systemOverlays")
+                true
+            } catch (_: ReflectiveOperationException) {
+                false
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchAdaptiveNavigationTest.kt
+++ b/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchAdaptiveNavigationTest.kt
@@ -42,6 +42,13 @@ class BookSearchAdaptiveNavigationTest {
         }
     }
 
+    @Test
+    fun paneDirective_doesNotAutoFocusDestination() {
+        val directive = calculateBookSearchPaneScaffoldDirective(windowAdaptiveInfo(widthDp = 599f))
+
+        assertFalse(directive.shouldAutoFocusCurrentDestination)
+    }
+
     private fun windowAdaptiveInfo(widthDp: Float): WindowAdaptiveInfo =
         WindowAdaptiveInfo(
             windowSizeClass = WindowSizeClass(widthDp = widthDp, heightDp = 800f),

--- a/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchAdaptiveNavigationTest.kt
+++ b/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/booksearch/BookSearchAdaptiveNavigationTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.Posture
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.window.core.layout.WindowSizeClass
-import org.junit.Assert.assertEquals
+import liou.rayyuan.ebooksearchtaiwan.booksearch.util.isWindowWidthCompact
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -22,15 +22,29 @@ class BookSearchAdaptiveNavigationTest {
     }
 
     @Test
-    fun mediumWidth_usesTwoPaneScaffoldDirective() {
-        val mediumWindowInfo =
-            WindowAdaptiveInfo(
-                windowSizeClass = WindowSizeClass.compute(dpWidth = 700f, dpHeight = 800f),
-                windowPosture = Posture()
-            )
-
-        val directive = calculateBookSearchPaneScaffoldDirective(mediumWindowInfo)
-
-        assertEquals(2, directive.maxHorizontalPartitions)
+    fun compactWidth_isCompact() {
+        assertTrue(isWindowWidthCompact(windowAdaptiveInfo(widthDp = 599f)))
     }
+
+    @Test
+    fun mediumAndLargerWidths_areNotCompact() {
+        listOf(600f, 840f, 1200f, 1600f).forEach { widthDp ->
+            assertFalse(isWindowWidthCompact(windowAdaptiveInfo(widthDp)))
+        }
+    }
+
+    @Test
+    fun mediumAndLargerWidths_useTwoPaneScaffoldDirective() {
+        listOf(600f, 840f, 1200f, 1600f).forEach { widthDp ->
+            val directive = calculateBookSearchPaneScaffoldDirective(windowAdaptiveInfo(widthDp))
+
+            assertTrue(directive.maxHorizontalPartitions >= 2)
+        }
+    }
+
+    private fun windowAdaptiveInfo(widthDp: Float): WindowAdaptiveInfo =
+        WindowAdaptiveInfo(
+            windowSizeClass = WindowSizeClass(widthDp = widthDp, heightDp = 800f),
+            windowPosture = Posture()
+        )
 }

--- a/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/utils/WindowApiCompatibilityTest.kt
+++ b/app/src/test/kotlin/liou/rayyuan/ebooksearchtaiwan/utils/WindowApiCompatibilityTest.kt
@@ -1,0 +1,35 @@
+package liou.rayyuan.ebooksearchtaiwan.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WindowApiCompatibilityTest {
+    @Test
+    fun apiBelow34_doesNotRequireSystemOverlaysMethod() {
+        assertTrue(
+            isWindowInsetsRuntimeCompatible(sdkInt = 33) {
+                throw AssertionError("Method lookup should not run below API 34")
+            }
+        )
+    }
+
+    @Test
+    fun api34WithSystemOverlaysMethod_isSupported() {
+        assertTrue(isWindowInsetsRuntimeCompatible(sdkInt = 34) { true })
+    }
+
+    @Test
+    fun api34WithoutSystemOverlaysMethod_isNotSupported() {
+        assertFalse(isWindowInsetsRuntimeCompatible(sdkInt = 34) { false })
+    }
+
+    @Test
+    fun api34WithLinkageError_isNotSupported() {
+        assertFalse(
+            isWindowInsetsRuntimeCompatible(sdkInt = 34) {
+                throw NoSuchMethodError("systemOverlays")
+            }
+        )
+    }
+}

--- a/docs/spec/known-limitations.md
+++ b/docs/spec/known-limitations.md
@@ -10,7 +10,7 @@
 
 ## Adaptive UI
 
-`LIMIT-003` 大畫面／分欄判定以 Material 3 Adaptive 的 `WindowSizeClass` 為準：Compact 為單欄，Medium 及以上為分欄。Adaptive 1.1.0 的標準 directive 在 Medium 仍為單欄，因此 App 必須明確使用 `calculatePaneScaffoldDirectiveWithTwoPanesOnMediumWidth`（或維持相同分欄語意的後續 API），不可依賴 navigator 預設值。
+`LIMIT-003` 大畫面／分欄判定以 Material 3 Adaptive 的 `WindowSizeClass` 為準：Compact 為單欄，Medium 及以上為分欄。App 必須明確使用 `calculatePaneScaffoldDirectiveWithTwoPanesOnMediumWidth`（或維持相同分欄語意的後續 API），不可依賴 navigator 預設值。
 
 此判定來源可隨官方 Adaptive API 演進而調整，但必須維持 `NAV-001` 至 `NAV-004`：單欄可用 Custom Tab 偏好，分欄則在詳細區域顯示 App 內商品頁。
 

--- a/docs/spec/navigation-sharing-deep-links.md
+++ b/docs/spec/navigation-sharing-deep-links.md
@@ -6,7 +6,7 @@
 
 `NAV-002` Compact／單欄且使用者關閉「使用瀏覽器分頁」後，商品連結改在 App 內建 WebView 顯示。
 
-`NAV-003` Medium+／分欄固定在清單旁的詳細區域使用內建 WebView，不受 Custom Tab 偏好影響。Adaptive 1.1.0 必須使用 Medium 雙欄 directive；其標準 directive 在 Medium 仍為單欄。原因是現有 Custom Tab 無法嵌入右側詳細區域。
+`NAV-003` Medium+／分欄固定在清單旁的詳細區域使用內建 WebView，不受 Custom Tab 偏好影響。App 必須明確使用從 Medium 起提供雙欄的 pane directive，不可依賴 Adaptive navigator 的預設值。原因是現有 Custom Tab 無法嵌入右側詳細區域。
 
 `NAV-004` 內建 WebView 必須提供返回 App 清單的操作，並提供分享目前商品及改用外部瀏覽器開啟的選項。
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,9 @@ guavaVersion = "31.1-android" # To prevent Guava conflict, use this old version
 
 #  Google Libraries
 androidxAppCompat = "1.7.1"
-androidxCore = "1.17.0"
+androidxCore = "1.19.0"
 androidxActivity = "1.11.0"
+androidxWindow = "1.5.1"
 androidxPreference = "1.2.1"
 androidxBrowser = "1.9.0"
 materialDesign = "1.13.0"
@@ -19,7 +20,7 @@ barcodeScanner = "17.3.0"
 appfunctions = "1.0.0-alpha10"
 
 # Jetpack Compose
-composeBom = "2025.10.00" # TODO: check the TextInput focus issue in newer version
+composeBom = "2026.08.00" # TODO: check the TextInput focus issue in newer version
 lifecycleCompose = "2.9.4"
 navigationCompose = "2.9.5"
 constraintlayoutCompose = "1.1.1"
@@ -84,6 +85,7 @@ desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", ver
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity", version.ref = "androidxActivity" }
+androidx-window = { group = "androidx.window", name = "window", version.ref = "androidxWindow" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreference" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
 material = { group = "com.google.android.material", name = "material", version.ref = "materialDesign" }


### PR DESCRIPTION
## Summary
- upgrade Compose, Material 3 Adaptive, AndroidX Core, and Window to stable versions that avoid the `WindowMetrics.getDensity()` startup crash path
- detect incomplete API 34 window runtimes and fall back from edge-to-edge Compose insets when `WindowInsets.Type.systemOverlays()` is unavailable
- preserve Compact and Medium+ navigation behavior while preventing Adaptive pane navigation from focusing the search field after returning from the built-in WebView
- align the Adaptive UI requirements and add unit and instrumented regression coverage

#### Test plan
- [x] `./gradlew spotlessCheck test lint assembleApiDebug :app:assembleApiRelease`
- [x] run the zero-insets fallback instrumentation test on a Pixel 8 Android 14 emulator
- [x] cold-launch `apiDebug` on Android 14
- [x] search with `mockDebug`, open a result in the built-in WebView, return to the list, and verify the search field remains unfocused
- [x] verify Compact, Medium, Expanded, Large, and Extra Large window breakpoint behavior

Lint completes with the existing `SuspiciousModifierThen` baseline error because `abortOnError = false`; this change adds no new Lint error.

Generated with [Devin](https://devin.ai)